### PR TITLE
fixed footnotes direction

### DIFF
--- a/middle-east-night.css
+++ b/middle-east-night.css
@@ -379,6 +379,10 @@ sup.md-footnote {
   padding: 0 4px;
 }
 
+.footnotes, .footnotes-area {
+  direction: rtl;
+}
+
 span.md-def-split {
   min-width: 1ch;
 }
@@ -388,6 +392,13 @@ span.md-def-split {
   color: var(--meta-content-color);
 }
 
+.md-def-footnote .md-def-name:before, .md-def-name:before {
+  content: ']: '
+}
+
+.md-def-name:after {
+  content: '[^ ';
+}
 /* Writing area */
 #write {
   width: 90%;


### PR DESCRIPTION
Footnotes and link references were left-to-right directed, it was inconvenience to write. Now everything works as expected. 
## Example
Before:
![image](https://user-images.githubusercontent.com/11134754/87414310-e4730e80-c5cb-11ea-84e3-20af02a4be3c.png)

After:
![image](https://user-images.githubusercontent.com/11134754/87414261-cf967b00-c5cb-11ea-991e-6a53eea02121.png)
