### PR TITLE
Add RTL to footnote

### DIFF
--- a/middle-east-night.css
+++ b/middle-east-night.css
@@ -753,3 +753,15 @@ footer.ty-footer {
     display: none;
   }
 }
+
+.md-def-footnote {
+  direction: rtl;
+}
+
+.md-def-name::before {
+  content: '] :' !important
+}
+
+.md-def-name::after {
+  content: '[^'
+}


### PR DESCRIPTION
Footnotes are left to right. This commit make them right to left.